### PR TITLE
enable to use top

### DIFF
--- a/vcluster/Dockerfile
+++ b/vcluster/Dockerfile
@@ -21,6 +21,7 @@ RUN tar -xvf mpich-3.2.tar.gz
 RUN cd mpich-3.2 && ./configure --prefix=/opt/mpich && make -j4 && make install
 RUN cd /root/benchmark/mpi/gemm && make
 RUN echo export PATH=/opt/mpich/bin:$PATH >> ~/.bashrc
+RUN echo export export TERM=xterm >> ~/.bashrc
 RUN echo export LD_LIBRARY_PATH=/opt/mpich/lib:$LD_LIBRARY_PATH >> ~/.bashrc
 RUN echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN cp /root/benchmark/mpi/tools/demo.sh /root

--- a/vcluster/Dockerfile
+++ b/vcluster/Dockerfile
@@ -21,7 +21,7 @@ RUN tar -xvf mpich-3.2.tar.gz
 RUN cd mpich-3.2 && ./configure --prefix=/opt/mpich && make -j4 && make install
 RUN cd /root/benchmark/mpi/gemm && make
 RUN echo export PATH=/opt/mpich/bin:$PATH >> ~/.bashrc
-RUN echo export export TERM=xterm >> ~/.bashrc
+RUN echo export TERM=xterm >> ~/.bashrc
 RUN echo export LD_LIBRARY_PATH=/opt/mpich/lib:$LD_LIBRARY_PATH >> ~/.bashrc
 RUN echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN cp /root/benchmark/mpi/tools/demo.sh /root


### PR DESCRIPTION
When I using "top" command, it shows the message "TERM environment variable not set
". I add "RUN echo export TERM=xterm >> ~/.bashrc" in Dockerfile and it helps us to use "top" commands in a container.